### PR TITLE
Fix layout of logos in GlobalDisclaimer.html in IE11.

### DIFF
--- a/lib/Views/GlobalDisclaimer.html
+++ b/lib/Views/GlobalDisclaimer.html
@@ -3,26 +3,26 @@
 <p>This online tool gives access to information about the state and condition of global rangelands. It provides time-series data on the vegetation and environmental conditions, allowing national and regional tracking of the resources which sustains livestock production. It has been developed, and is currently hosted, by <a href="https://www.data61.csiro.au/">Data61</a> with the assistance of IT resources and services from the <a href="https://nci.org.au/">National Computational Infrastructure (NCI)</a>, and the <a href="http://www.auscover.org.au/">AusCover</a> facility.</p>
 <p>RAPP Map is supported by <a href="https://www.csiro.au/">CSIRO</a> and through funding from the <a href="http://www.nrm.gov.au/">Australian Government’s National Landcare Programme</a>.</p>
 <p>
-    <div style="background: white; color: black">
-        <div style="display: inline-block; width: 133px; height: 40px; margin: 10px; text-align: center">
+    <div class="logoArea">
+        <div class="logo" style="width: 133px;">
             <img src="images/DATA61_CSIRO_OnWhite_RGB.svg" alt="Data61" height=40px>
         </div>
-        <div style="display: inline-block; width: 133px; height: 40px; margin: 10px; text-align: center">
+        <div class="logo" style="width: 133px;">
             <img src="images/nci_logo.svg" alt="NCI" height=40px>
         </div>
-        <div style="display: inline-block; width: 133px; height: 40px; margin: 10px; text-align: center">
+        <div class="logo" style="width: 133px;">
             <img src="images/data_cube.svg" alt="DataCube" height=40px>
         </div>
-        <div style="display: inline-block; width: 210px; height: 40px; margin: 10px; text-align: center">
+        <div class="logo" style="width: 210px;">
             <img src="images/national_landcare_programme.svg" alt="LandCare" height=40px>
         </div>
-        <div style="display: inline-block; width: 210px; height: 40px; margin: 10px; text-align: center">
+        <div class="logo" style="width: 210px;">
             <img src="images/tern_auscover.svg" alt="TERN AusCover" height=40px>
         </div>
-        <div style="display: inline-block; width: 210px; height: 40px; margin: 10px; text-align: center">
+        <div class="logo" style="width: 210px;">
             <img src="images/geo_logo_with_alternative_layout.png" alt="GEO" height=40px>
         </div>
-        <div style="display: inline-block; width: 210px; height: 40px; margin: 10px; text-align: center">
+        <div class="logo" style="width: 210px;">
             <img src="images/geoglam_alt.png" alt="GEOGLAM" height=40px>
         </div>
     </div>

--- a/wwwroot/geoglam.css
+++ b/wwwroot/geoglam.css
@@ -1,6 +1,6 @@
 
 
-// Global Livestock Custom hack
+/* Global Livestock Custom hack */
 
 .livestock0:after {
   content: ""
@@ -66,7 +66,7 @@
   content: "No classification"
 }
 
-// GlobCover Custom hack
+/* GlobCover Custom hack */
 
 .globcover11:after {
   content: "Post-flooding or Irrigated croplands"
@@ -158,4 +158,17 @@
 
 .globcover230:after {
   content: "Water/No data"
+}
+
+/* GlobalDisclaimer.html styles */
+.logoArea {
+    background: white;
+    color: black;
+}
+
+.logo {
+  display: inline-block;
+  text-align: center;
+  height: 40px;
+  margin: 10px;
 }


### PR DESCRIPTION
For unknown reasons, IE11 loses the `display: inline-block` style on the
way to the DOM.  Using legit CSS classes instead of inline styles fixes it.
