### PR TITLE
Convert features to GeoJSON when selecting an existing polgon.

### DIFF
--- a/lib/Models/SelectAPolygonParameter.js
+++ b/lib/Models/SelectAPolygonParameter.js
@@ -55,14 +55,15 @@ SelectAPolygonParameter.formatValueForUrl = function(value, parameter) {
     }
     var featureList = value.map(function(featureData) {
         return {
-            'type': 'Feature',
-            'geometry': featureData.geometry
+            type: 'Feature',
+            crs: featureData.crs,
+            geometry: featureData.geometry
         };
     });
 
     return JSON.stringify({
-        'type': 'FeatureCollection',
-        'features': featureList
+        type: 'FeatureCollection',
+        features: featureList
     });
 };
 
@@ -77,6 +78,7 @@ SelectAPolygonParameter.getGeoJsonFeature = function(value) {
     return value.map(function(featureData) {
         return {
             type: 'Feature',
+            crs: featureData.crs,
             geometry: featureData.geometry
         };
     });

--- a/lib/Views/SelectAPolygonParameterEditor.jsx
+++ b/lib/Views/SelectAPolygonParameterEditor.jsx
@@ -65,9 +65,12 @@ SelectAPolygonParameterEditor.selectOnMap = function(terria, viewState, paramete
             }
 
             const catalogItems = pickedFeatures.features.map(function(feature) {
-                let geojson = featureDataToGeoJson(feature.data);
-                if (geojson && !defined(geojson.id) && defined(feature.id)) {
-                    geojson.id = feature.id;
+                let geojson;
+                if (feature.data) {
+                    geojson = featureDataToGeoJson(feature.data);
+                    if (geojson && !defined(geojson.id) && defined(feature.id)) {
+                        geojson.id = feature.id;
+                    }
                 } else {
                     const positions = feature.polygon.hierarchy.getValue().positions.map(function(position) {
                         const cartographic = Ellipsoid.WGS84.cartesianToCartographic(position);

--- a/lib/Views/SelectAPolygonParameterEditor.jsx
+++ b/lib/Views/SelectAPolygonParameterEditor.jsx
@@ -3,6 +3,7 @@ import CesiumMath from 'terriajs-cesium/Source/Core/Math';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import Ellipsoid from 'terriajs-cesium/Source/Core/Ellipsoid';
 import featureDataToGeoJson from 'terriajs/lib/Map/featureDataToGeoJson';
+import GeoJsonCatalogItem from 'terriajs/lib/Models/GeoJsonCatalogItem';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
 import MapInteractionMode from 'terriajs/lib/Models/MapInteractionMode';
 import ObserveModelMixin from 'terriajs/lib/ReactViews/ObserveModelMixin';
@@ -59,34 +60,41 @@ SelectAPolygonParameterEditor.selectOnMap = function(terria, viewState, paramete
 
     knockout.getObservable(pickPolygonMode, 'pickedFeatures').subscribe(function(pickedFeatures) {
         when(pickedFeatures.allFeaturesAvailablePromise, function() {
-            if (defined(pickedFeatures.pickPosition)) {
-                const value = pickedFeatures.features.map(function(feature) {
-                        if (defined(feature.data)) {
-                            const geojson = featureDataToGeoJson(feature.data);
-                            if (geojson && !defined(geojson.id) && defined(feature.id)) {
-                                geojson.id = feature.id;
-                            }
-                            return geojson;
-                        }
-                        const positions = feature.polygon.hierarchy.getValue().positions.map(function(position) {
-                            const cartographic = Ellipsoid.WGS84.cartesianToCartographic(position);
-                            return [CesiumMath.toDegrees(cartographic.longitude), CesiumMath.toDegrees(cartographic.latitude)];
-                        });
-
-                        return {
-                            id: feature.id,
-                            type: "Feature",
-                            properties: feature.properties,
-                            geometry: {
-                                coordinates: [[positions]],
-                                type: "MultiPolygon",
-                            }
-                        };
-                    });
-                parameter.value = value;
-                terria.mapInteractionModeStack.pop();
-                viewState.openAddData();
+            if (!defined(pickedFeatures.pickPosition)) {
+                return [];
             }
+
+            const catalogItems = pickedFeatures.features.map(function(feature) {
+                let geojson = featureDataToGeoJson(feature.data);
+                if (geojson && !defined(geojson.id) && defined(feature.id)) {
+                    geojson.id = feature.id;
+                } else {
+                    const positions = feature.polygon.hierarchy.getValue().positions.map(function(position) {
+                        const cartographic = Ellipsoid.WGS84.cartesianToCartographic(position);
+                        return [CesiumMath.toDegrees(cartographic.longitude), CesiumMath.toDegrees(cartographic.latitude)];
+                    });
+
+                    geojson = {
+                        id: feature.id,
+                        type: "Feature",
+                        properties: feature.properties,
+                        geometry: {
+                            coordinates: [[positions]],
+                            type: "MultiPolygon",
+                        }
+                    };
+                }
+
+                const catalogItem = new GeoJsonCatalogItem(terria);
+                catalogItem.data = geojson;
+                return catalogItem;
+            });
+            const promises = catalogItems.map(item => item.load());
+            return when.all(promises).then(() => catalogItems);
+        }).then(function(catalogItems) {
+            parameter.value = catalogItems.map(item => item._readyData);
+            terria.mapInteractionModeStack.pop();
+            viewState.openAddData();
         });
     });
 

--- a/lib/Views/SelectAPolygonParameterEditor.jsx
+++ b/lib/Views/SelectAPolygonParameterEditor.jsx
@@ -1,13 +1,12 @@
-import React from 'react';
-
 import Cartographic from 'terriajs-cesium/Source/Core/Cartographic';
 import CesiumMath from 'terriajs-cesium/Source/Core/Math';
 import defined from 'terriajs-cesium/Source/Core/defined';
 import Ellipsoid from 'terriajs-cesium/Source/Core/Ellipsoid';
+import featureDataToGeoJson from 'terriajs/lib/Map/featureDataToGeoJson';
 import knockout from 'terriajs-cesium/Source/ThirdParty/knockout';
-
 import MapInteractionMode from 'terriajs/lib/Models/MapInteractionMode';
 import ObserveModelMixin from 'terriajs/lib/ReactViews/ObserveModelMixin';
+import React from 'react';
 import Styles from 'terriajs/lib/ReactViews/Analytics/parameter-editors.scss';
 import when from 'terriajs-cesium/Source/ThirdParty/when';
 
@@ -63,7 +62,11 @@ SelectAPolygonParameterEditor.selectOnMap = function(terria, viewState, paramete
             if (defined(pickedFeatures.pickPosition)) {
                 const value = pickedFeatures.features.map(function(feature) {
                         if (defined(feature.data)) {
-                            return feature.data;
+                            const geojson = featureDataToGeoJson(feature.data);
+                            if (geojson && !defined(geojson.id) && defined(feature.id)) {
+                                geojson.id = feature.id;
+                            }
+                            return geojson;
                         }
                         const positions = feature.polygon.hierarchy.getValue().positions.map(function(position) {
                             const cartographic = Ellipsoid.WGS84.cartesianToCartographic(position);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "http://github.com/TerriaJS/geoglam-nm"
   },
   "dependencies": {
-    "terriajs-server": "^2.6.7"
+    "terriajs-server": "^2.6.2"
   },
   "config": {
     "awsProfile": "geoglam-nm",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.0.0",
-    "babel-loader": "^6.4.0",
+    "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "css-loader": "^0.28.0",
@@ -36,12 +36,12 @@
     "eslint-plugin-react": "^6.5.0",
     "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.11.1",
-    "fs-extra": "^2.0.0",
+    "fs-extra": "^3.0.0",
     "generate-terriajs-schema": "^1.3.0",
     "gulp": "^3.9.1",
     "gulp-util": "^3.0.7",
     "json5": "^0.5.0",
-    "jsx-control-statements": "3.1.5",
+    "jsx-control-statements": "3.2.5",
     "node-notifier": "^5.1.2",
     "node-sass": "^4.0.0",
     "raw-loader": "^0.5.1",
@@ -51,11 +51,11 @@
     "resolve-url-loader": "^2.0.2",
     "sass-loader": "^6.0.3",
     "semver": "^5.0.0",
-    "style-loader": "^0.16.1",
+    "style-loader": "^0.18.0",
     "svg-sprite-loader": "^0.3.0",
-    "terriajs": "5.1.0",
+    "terriajs": "TerriaJS/terriajs",
     "terriajs-catalog-editor": "^0.2.0",
-    "terriajs-cesium": "1.31.1",
+    "terriajs-cesium": "1.33.0",
     "terriajs-schema": "latest",
     "urijs": "^1.17.1",
     "url-loader": "^0.5.7",


### PR DESCRIPTION
This is at least a partial fix for #16.  The polygon name shows up now, and it appears to be sending valid GeoJSON, but the server is returning 500 with this text:
>  Error trying to read ./templates/WPS_Exception.tpl file: open ./templates/WPS_Exception.tpl: no such file or directory

The only difference I see between a working WMS request and a failing ArcGIS request is that in the WMS the GeoJSON is a `MultiPolygon` but in the ArcGIS it is a `Polygon`.