### PR TITLE
add SSM permissions to cloud formation

### DIFF
--- a/deploy/aws/stack.json
+++ b/deploy/aws/stack.json
@@ -346,6 +346,9 @@
           ]
         },
         "Path": "/",
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+        ],
         "Policies": [
           {
             "PolicyDocument": {

--- a/deploy/aws/stack.json
+++ b/deploy/aws/stack.json
@@ -347,7 +347,7 @@
         },
         "Path": "/",
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+          "arn:aws:iam::242476885589:policy/SSM-Policy"
         ],
         "Policies": [
           {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "awsProfile": "geoglam-nm",
     "awsS3PackagesPath": "s3://geoglam-apps/map",
     "awsRegion": "ap-southeast-2",
-    "awsEc2InstanceType": "t2.nano",
+    "awsEc2InstanceType": "t2.small",
     "awsEc2ImageId": "ami-0065540df76a93885",
     "awsKeyName": "mhenrikson",
     "awsS3ServerConfigOverridePath": "s3://geoglam-apps/map/privateserverconfig-2016-10-27.json",


### PR DESCRIPTION
This adds an AWS managed IAM policy to the instance profile that EC2 instances use to access AWS services.

The policy being added allows the AWS SSM service to talk to/from the servers.