### PR TITLE
use aws managed SSM role

### DIFF
--- a/deploy/aws/stack.json
+++ b/deploy/aws/stack.json
@@ -347,7 +347,7 @@
         },
         "Path": "/",
         "ManagedPolicyArns": [
-          "arn:aws:iam::242476885589:policy/SSM-Policy"
+          "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
         ],
         "Policies": [
           {


### PR DESCRIPTION
Updates IAM instance profile to use the new AWS managed IAM policy for SSM access instead of the one we created.